### PR TITLE
Adding array to string conversion in the validator error messages

### DIFF
--- a/src/Violin.php
+++ b/src/Violin.php
@@ -255,13 +255,18 @@ class Violin implements ValidatorContract
             $message = str_replace($argReplace, $args, $message);
         }
 
+        /*
+         *  Catch the possibility of the value being an array and
+         *  perform a safe array->string conversion if so.
+         */
+        $value = $item['value'];
+        $safe_value = is_array($value)?implode(', ', $value):$value;
         // Replace field and value
         $message = str_replace(
             ['{field}', '{value}'],
-            [$item['field'], $item['value']],
+            [$item['field'], $safe_value],
             $message
         );
-
         return $message;
     }
 
@@ -283,7 +288,7 @@ class Violin implements ValidatorContract
         if ($this->canSkipRule($ruleToCall, $value)) {
             return;
         }
-        
+
         $passed = call_user_func_array($ruleToCall, [
             $value,
             $this->input,

--- a/tests/ValidatorTest.php
+++ b/tests/ValidatorTest.php
@@ -269,4 +269,44 @@ class ValidatorTest extends PHPUnit_Framework_TestCase
 
         $this->assertEmpty($this->v->errors()->all());
     }
+
+    public function testArrayValidation(){
+        $this->v->validate([
+            'items' => [ [1,2,3,4], 'required']
+        ]);
+
+        $this->assertTrue($this->v->passes());
+        $this->assertEmpty($this->v->errors()->all());
+
+        $this->v->addFieldMessages([
+            'items' => [
+                'required' => 'We need some items in the {field} field, please.'
+            ]
+        ]);
+
+        $this->v->validate([
+            'items|Items' => [ [], 'required']
+        ]);
+
+        $errors = $this->v->errors();
+        $this->assertFalse($this->v->passes());
+        $this->assertTrue($this->v->fails());
+        $this->assertEquals(
+            $errors->first('items'),
+            'We need some items in the Items field, please.'
+        );
+
+        $this->v->validate([
+            'items|Items' => [ [2,3,4], 'required|matches(other_items)'],
+            'other_items' => [ [1,2,3], 'required']
+        ]);
+
+        $errors = $this->v->errors();
+        $this->assertFalse($this->v->passes());
+        $this->assertTrue($this->v->fails());
+        $this->assertEquals(
+            $errors->first('items'),
+            'Items must match other_items.'
+        );
+    }
 }


### PR DESCRIPTION
Catching an item's value being an array before the validator hits an array to string conversion error.

Also added tests for this change.